### PR TITLE
Upgrade deno to v2.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,16 @@ description = "A javascript runtime with [pjs](https://github.com/polkadot-js) e
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-deno_ast = { version = "0.38", features = ["transpiling"] }
-deno_core = "0.272.0"
+deno_ast = { version = "0.43.3", features = ["transpiling"] }
+deno_core = "0.321.0"
+deno_permissions = "0.39.0"
+deno_console = "0.179.0"
+deno_webidl = "0.179.0"
+deno_fetch = "0.203.0"
+deno_crypto = "0.193.0"
+deno_url = "0.179.0"
+deno_web = "0.210.0"
+deno_websocket = "0.184.0"
+deno_net = "0.171.0"
+log = "0.4.22"
 tokio = { version = "1.37.0", features = ["full"] }
-deno_console = "0.143.0"
-deno_webidl = "0.144.0"
-deno_fetch = "0.167.0"
-deno_crypto = "0.157.0"
-deno_url = "0.143.0"
-deno_web = "0.174.0"
-deno_websocket = "0.149.0"
-log = "0.4.21"

--- a/src/perms.rs
+++ b/src/perms.rs
@@ -1,10 +1,12 @@
-use std::path::Path;
+use std::borrow::Cow;
+use std::path::{Path, PathBuf};
 
-use deno_core::error::AnyError;
 use deno_core::url::Url;
 use deno_fetch::FetchPermissions;
+use deno_net::NetPermissions;
 use deno_web::TimersPermission;
 use deno_websocket::WebSocketPermissions;
+use deno_permissions::PermissionCheckError;
 
 pub struct ZombiePermissions;
 
@@ -26,16 +28,34 @@ impl WebSocketPermissions for ZombiePermissions {
         &mut self,
         _url: &deno_core::url::Url,
         _api_name: &str,
-    ) -> Result<(), AnyError> {
+    ) -> Result<(), PermissionCheckError> {
         Ok(())
     }
 }
 
 impl FetchPermissions for ZombiePermissions {
-    fn check_net_url(&mut self, _url: &Url, _api_name: &str) -> Result<(), AnyError> {
+    fn check_net_url(&mut self, _url: &Url, _api_name: &str) -> Result<(), PermissionCheckError> {
         Ok(())
     }
-    fn check_read(&mut self, _p: &Path, _api_name: &str) -> Result<(), AnyError> {
+    fn check_read<'a>(&mut self, p: &'a Path, _api_name: &str) -> Result<Cow<'a, Path>, PermissionCheckError> {
+        Ok(p.into())
+    }
+}
+
+impl NetPermissions for ZombiePermissions {
+    fn check_net<T: AsRef<str>>(&mut self, _host: &(T, Option<u16>), _api_name: &str) -> Result<(), PermissionCheckError> {
         Ok(())
+    }
+
+    fn check_read(&mut self, p: &str, _api_name: &str) -> Result<PathBuf, PermissionCheckError> {
+        Ok(p.into())
+    }
+
+    fn check_write(&mut self, p: &str, _api_name: &str) -> Result<PathBuf, PermissionCheckError> {
+        Ok(p.into())
+    }
+
+    fn check_write_path<'a>(&mut self, p: &'a Path, _api_name: &str) -> Result<Cow<'a, Path>, PermissionCheckError> {
+        Ok(p.into())
     }
 }


### PR DESCRIPTION
Old Deno pin `log` to `0.4.20`, which block `zombienet-sdk` upgrade `reqwest`

I wanna upgrade to the latest `v2.1.4`. However, I meet a mysterious issue:
```
---- tests::query_historic_data_rococo_works stdout ----
thread 'tests::query_historic_data_rococo_works' panicked at /Users/jasl/.cargo/registry/src/index.crates.io-6f17d22bba15001f/deno_core-0.324.0/runtime/jsruntime.rs:745:9:
Failed to initialize a JsRuntime: Uncaught SyntaxError: Unexpected reserved word
    at ext:deno_telemetry/telemetry.ts:62:1
```
I did some research, but unfortunately, I didn't know why, so I gave up, and v2.1.1 is new enough.
The issue came from https://github.com/denoland/deno/pull/27067

Maybe relates to my network issue, I ran tests in my local machine, got:
```
[out]: "Alice has an updated balance of" "21,193,448,276,138"
[err]: 2024-12-17 04:48:40,       RPC-CORE:,submitAndWatchExtrinsic(extrinsic: Extrinsic): ExtrinsicStatus:: 1014: Priority is too low: (12451 vs 11720): The transaction has too low priority to replace another transaction already in the pool.
[err]: "2024-12-17 04:48:40" "       RPC-CORE:" "submitAndWatchExtrinsic(extrinsic: Extrinsic): ExtrinsicStatus:: 1014: Priority is too low: (12451 vs 11720): The transaction has too low priority to replace another transaction already in the pool."
[err]: 2024-12-17 04:48:40,       RPC-CORE:,submitAndWatchExtrinsic(extrinsic: Extrinsic): ExtrinsicStatus:: 1014: Priority is too low: (12451 vs 11720): The transaction has too low priority to replace another transaction already in the pool.
[err]: "2024-12-17 04:48:40" "       RPC-CORE:" "submitAndWatchExtrinsic(extrinsic: Extrinsic): ExtrinsicStatus:: 1014: Priority is too low: (12451 vs 11720): The transaction has too low priority to replace another transaction already in the pool."
test tests::transfer_works ... FAILED
```