### PR TITLE
Upgrade Deno to v2.1.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,19 @@ description = "A javascript runtime with [pjs](https://github.com/polkadot-js) e
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-deno_ast = { version = "0.43.3", features = ["transpiling"] }
-deno_core = "0.321.0"
-deno_permissions = "0.39.0"
-deno_console = "0.179.0"
-deno_webidl = "0.179.0"
-deno_fetch = "0.203.0"
-deno_crypto = "0.193.0"
-deno_url = "0.179.0"
-deno_web = "0.210.0"
-deno_websocket = "0.184.0"
-deno_net = "0.171.0"
-log = "0.4.22"
-tokio = { version = "1.37.0", features = ["full"] }
+deno_ast = { version = "0.44.0", features = ["transpiling"] }
+deno_core = "0.336.0"
+deno_io = "0.100.0"
+deno_runtime = { version = "0.198.0", features = ["transpile"] }
+deno_permissions = "0.49.0"
+deno_console = "0.190.0"
+deno_webidl = "0.190.0"
+deno_fetch = "0.214.0"
+deno_crypto = "0.204.0"
+deno_url = "0.190.0"
+deno_web = "0.221.0"
+deno_websocket = "0.195.0"
+deno_net = "0.182.0"
+deno_telemetry = "0.12.0"
+log = "0.4.25"
+tokio = { version = "1.43.0", features = ["full"] }

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,9 +1,9 @@
 use crate::perms::ZombiePermissions;
-use deno_core::error::AnyError;
+use deno_core::error::CoreError;
 use deno_core::op2;
 
 #[op2(async)]
-async fn op_set_timeout(#[bigint] delay: u64) -> Result<(), AnyError> {
+async fn op_set_timeout(#[bigint] delay: u64) -> Result<(), CoreError> {
     tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
     Ok(())
 }

--- a/src/perms.rs
+++ b/src/perms.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use deno_core::url::Url;
 use deno_fetch::FetchPermissions;
+use deno_io::fs::FsError;
 use deno_net::NetPermissions;
 use deno_permissions::PermissionCheckError;
 use deno_web::TimersPermission;
@@ -37,11 +38,13 @@ impl FetchPermissions for ZombiePermissions {
     fn check_net_url(&mut self, _url: &Url, _api_name: &str) -> Result<(), PermissionCheckError> {
         Ok(())
     }
+
     fn check_read<'a>(
         &mut self,
+        _resolved: bool,
         p: &'a Path,
         _api_name: &str,
-    ) -> Result<Cow<'a, Path>, PermissionCheckError> {
+    ) -> Result<Cow<'a, Path>, FsError> {
         Ok(p.into())
     }
 }


### PR DESCRIPTION
I just realized why `telemetry` ext won't work.
Now, I can upgrade to the latest Deno.

The previous PR has already loosened requirements, so this one is nit.